### PR TITLE
Fix undefined behavior in USBDevice EP destructor

### DIFF
--- a/cores/arduino/USB/SAMD21_USBDevice.h
+++ b/cores/arduino/USB/SAMD21_USBDevice.h
@@ -253,8 +253,6 @@ public:
 	}
 
 	virtual ~DoubleBufferedEPOutHandler() {
-		free((void*)data0);
-		free((void*)data1);
 	}
 
 	virtual uint32_t recv(void *_data, uint32_t len)


### PR DESCRIPTION
The recent change in https://github.com/Dygmalab/Kaleidoscope-Bundle-Dygma/pull/2 converted data0 and data1 to fixed-length arrays, but the free calls in the destructor remained, causing undefined behavior. I noticed that when calling unbind and bind on the USB port I would get a failed to set config error on my PC and the keyboard wouldn't work at all (except for the LEDs), but unplugging and replugging the USB cable would fix it. I also sometimes had to unplug and replug after starting up the PC.
Oddly I hadn't seen this issue before, while I was testing PR#2, but I got a new motherboard today, and after I had installed it the problems started appearing.

With this change I am able to unbind and bind without the error above, and it always works after turning on the PC.

I probably should have caught this when doing the original PR, but I assumed the upstream change was fine, so I didn't look through it super closely.